### PR TITLE
Rewrite of plugin JS

### DIFF
--- a/index.html
+++ b/index.html
@@ -115,8 +115,15 @@ $('.checkradios').checkradios();
             
             
             <div class="label">Output:</div>
-            <input type="checkbox" class="checkradios" checked/>
-            <input type="radio" class="checkradios" checked/>
+
+            <label for="checkbox-with-lable">
+                Labeled Checkbox:
+                <input id="checkbox-with-lable" type="checkbox" class="checkradios" checked/>
+            </label>
+            <label for="radio-with-label">
+                Labeled Radio:
+                <input id="radio-with-label" type="radio" class="checkradios" checked/>
+            </label>
         </div>
         
         

--- a/index.html
+++ b/index.html
@@ -68,6 +68,9 @@ $(document).ready(function(){
 		       $('.status').html('Not Checked').css('color', 'red');
 		});
 
+    $('#callback-button').on('click', function() {
+        $('#callback-checkbox').prop('checked', true).change();
+    });
 
 });
 
@@ -224,11 +227,18 @@ $('.checkradios').checkradios({
 		   else
 		       $('.status').html('Not Checked').css('color', 'red');
 		});
+
+    $('#callback-button').on('click', function() {
+        $('#callback-checkbox').prop('checked', true).change();
+    });
             </pre>
             
             
             <div class="label">Output:</div>
             <input id="callback-checkbox" type="checkbox" class="custom-style" checked/>
+            <button id="callback-button" type="button">
+                Check it!
+            </button>
             <div class="status">Status will appear here</div>
         </div>
         

--- a/index.html
+++ b/index.html
@@ -241,9 +241,29 @@ $('.checkradios').checkradios({
             </button>
             <div class="status">Status will appear here</div>
         </div>
+
+        <div class="section">
+            <h3 class="section-title">
+                Disabled Elements Example:
+            </h3>
         
-        
-        
+            <div class="code-title">
+                HTML:
+            </div>
+
+             <pre class="code">
+&lt;input type="checkbox" class="checkradios" disabled checked/&gt;
+&lt;input type="checkbox" class="checkradios" disabled /&gt;
+&lt;input type="radio" class="checkradios" disabled checked/&gt;
+&lt;input type="radio" class="checkradios" disabled /&gt;
+             </pre>
+
+            <div class="label">Output:</div>
+            <input type="checkbox" class="checkradios" disabled checked/>
+            <input type="checkbox" class="checkradios" disabled />
+            <input type="radio" class="checkradios" disabled checked/>
+            <input type="radio" class="checkradios" disabled />
+        </div>
         
         
         <div class="section">

--- a/index.html
+++ b/index.html
@@ -59,27 +59,14 @@ $(document).ready(function(){
 	
 	
 	
-	$('#callback-checkbox').checkradios({
-	
-	    onChange: function(checked, $element, $realElement){
-		    
-			
-		   if(checked){
-			  
+	$('#callback-checkbox')
+        .checkradios()
+        .on('change', function() {
+		   if(this.checked)
 		       $('.status').html('Checked').css('color', 'green');
-		   
-		   }else{
-		   
+		   else
 		       $('.status').html('Not Checked').css('color', 'red');
-		   
-		   }
-		
-		}
-	
-	
-	});
-	
-	
+		});
 
 
 });
@@ -229,26 +216,14 @@ $('.checkradios').checkradios({
              
             <div class="code-title">Javascript</div>
             <pre class="code">
-$('#callback-checkbox').checkradios({
-	
-    onChange: function(checked){
-    
-    
-        if(checked){
-          
-           $('.status').html('Checked').css('color', 'green');
-        
-        }else{
-        
-           $('.status').html('Not Checked').css('color', 'red');
-        
-        }
-    
-    
-    }
-
-
-});
+	$('#callback-checkbox')
+        .checkradios()
+        .on('change', function() {
+		   if(this.checked)
+		       $('.status').html('Checked').css('color', 'green');
+		   else
+		       $('.status').html('Not Checked').css('color', 'red');
+		});
             </pre>
             
             

--- a/js/jquery.checkradios.js
+++ b/js/jquery.checkradios.js
@@ -133,6 +133,47 @@
         });
     }
 
+    function initGeneric(element, settings) {
+	    var facade = $('<div/>')
+            .addClass(settings.facadeClass)
+            .addClass(element.attr('class'));
+
+        element.replaceWith(facade).appendTo(facade);
+
+        var group = element.is(':radio')
+            ? $('input:radio[name=' + element.attr('name') + ']')
+            : element;
+
+        facade.on('click mousedown mouseup', function(event) {
+            event.target = element[0];
+            element.trigger(event);
+        });
+
+        facade.on('click', function() {
+            element.focus();
+        });
+
+        element.on('focus', function() {
+            facade.addClass('focus');
+        });
+
+        element.on('blur', function() {
+            facade.removeClass('focus');
+        });
+
+        element.on('checkradioSync', function() {
+			facade.toggleClass(settings.iconClass, element.prop('checked'));
+        });
+
+        element.on('change', function() {
+            group.trigger('checkradioSync');
+        });
+
+        element.on('click mousedown mouseup', function(event) {
+			event.stopPropagation();
+        });
+    }
+
 })(jQuery);
 
 $(document).ready(function () {

--- a/js/jquery.checkradios.js
+++ b/js/jquery.checkradios.js
@@ -100,6 +100,9 @@
         });
 
         element.on('click mousedown mouseup', function(event) {
+            // When the facade passes the event to the control, don't
+            // allow it to propagate back up to the facade, infinitely
+            // recursing. Propogation from the facade will still happen.
 			event.stopPropagation();
         });
     }

--- a/js/jquery.checkradios.js
+++ b/js/jquery.checkradios.js
@@ -1,370 +1,142 @@
 /*
-	CHECKRADIOS - jQuery plugin to allow custom styling of checkboxes
-	by Chris McGuckin (https://github.com/cosmicwheels)
-	
-	
-	License: MIT (http://opensource.org/licenses/MIT)
-	
-	
-	Credits:
-	---------------------------------------------------------------------------------
-	
-	icomoon (http://icomoon.io/)
-	
-	Please refer to the icomoon website for the license regarding their icons.
-	
-	---------------------------------------------------------------------------------
-	
-	Fontawesome (http://fortawesome.github.io/Font-Awesome/)
-	
-	Please refer to the fontawesome website for the license regarding their icons.
-	
-	---------------------------------------------------------------------------------
-	
-	Stephan Richter (https://github.com/strichter)
-	
-	Thanks to Stephan for pointing out and helping to add the triggering of events 
-	to help further mimic the checkboxes and radios as well as providing other
-	important bug fixes.
-	
-	---------------------------------------------------------------------------------
-	---------------------------------------------------------------------------------
-	
+    CHECKRADIOS - jQuery plugin to allow custom styling of checkboxes
+    by Chris McGuckin (https://github.com/cosmicwheels)
+
+
+    License: MIT (http://opensource.org/licenses/MIT)
+
+
+    Credits:
+    ---------------------------------------------------------------------------------
+
+    icomoon (http://icomoon.io/)
+
+    Please refer to the icomoon website for the license regarding their icons.
+
+    ---------------------------------------------------------------------------------
+
+    Fontawesome (http://fortawesome.github.io/Font-Awesome/)
+
+    Please refer to the fontawesome website for the license regarding their icons.
+
+    ---------------------------------------------------------------------------------
+
+    Stephan Richter (https://github.com/strichter)
+
+    Thanks to Stephan for pointing out and helping to add the triggering of events
+    to help further mimic the checkboxes and radios as well as providing other
+    important bug fixes.
+
+    ---------------------------------------------------------------------------------
+    ---------------------------------------------------------------------------------
+
 
 */
+
 (function ($) {
-
-
-	$.fn.checkradios = function (options) {
-
-		var $elements = this;
-
-		//Default Settings
-		var settings = $.extend({
-
-			checkbox: {
-
-				iconClass: 'icon-checkradios-checkmark'
-
-			},
-
-			radio: {
-
-				iconClass: 'icon-checkradios-circle'
-
-			},
-
-
-			onChange: function (checked, $element, $realElement) {}
-
-		}, options);
-
-
-		// Functionality
-		var form = {
-
-			checkbox: function ($checkbox) {
-				
-
-				var THIS = this;
-
-				//Make sure checkradios isnt already in use
-				if (!$checkbox.parent().hasClass('checkradios-checkbox')) {
-
-					//Get the elements classes
-					var classes = $checkbox.attr('class');
-
-					if (classes === undefined) {
-
-						classes = '';
-
-					}
-
-					//Wrap the input
-					var $item = $checkbox.wrap('<div class="checkradios-checkbox ' + classes + '"/>');
-
-					//Get the new checkbox
-					var $holder = $item.parent();
-
-					//Check if box is checked
-					if ($item.is(':checked')) {
-
-						THIS.checkboxEnable($item);
-
-					} else {
-
-						THIS.checkboxDisable($item);
-
-					}
-
-					//Add keyboard support
-					$checkbox.keypress(function (e) {
-
-						var key = e.keyCode;
-
-						//On enter/return or space
-						if ((key < 1) || (key == 13) || (key == 32)) {
-
-							$holder.click();
-
-						}
-
-					});
-
-
-					//Add tabbing support
-					$checkbox.on({
-
-						focusin: function () {
-
-							$holder.addClass('focus');
-
-						},
-
-						focusout: function () {
-
-							var $this = $(this);
-
-							setTimeout(function () {
-
-								if (!$this.is(':focus')) {
-
-									$holder.removeClass('focus');
-
-								}
-
-							}, 10);
-
-						}
-					});
-
-
-					$holder.mousedown(function () {
-
-						setTimeout(function () {
-
-							//Add focus
-							$checkbox.focus();
-
-						}, 10);
-
-					});
-
-
-					//Disable usual click functionality
-					$checkbox.click(function (e) {
-
-						e.stopPropagation();
-						e.preventDefault();
-
-					});
-
-
-					//On button click
-					$holder.click(function () {
-
-						//Add check
-						if ($item.is(':checked')) {
-
-							THIS.checkboxDisable($item);
-
-							//Callback
-							settings.onChange(false, $holder, $item);
-
-						} else {
-
-							THIS.checkboxEnable($item);
-
-							//Callback
-							settings.onChange(true, $holder, $item);
-
-						}
-
-						return false;
-
-					});
-
-				}
-
-			},
-
-
-			radio: function ($radio) {
-
-				var THIS = this;
-
-				//Make sure checkradios isnt already in use
-				if (!$radio.parent().hasClass('checkradios-radio')) {
-
-					//Get the elements classes
-					var classes = $radio.attr('class');
-
-					if (classes === undefined) {
-
-						classes = '';
-
-					}
-
-					//Wrap the input
-					var $item = $radio.wrap('<div class="checkradios-radio ' + classes + '"/>');
-
-					//Get the new checkbox
-					var $holder = $item.parent();
-
-					//Check if box is checked
-					if ($item.is(':checked')) {
-
-						THIS.radioEnable($item);
-
-					} else {
-
-						THIS.radioDisable($item);
-
-					}
-
-					//Add tabbing suppot
-					$radio.on({
-						
-						focusin: function () {
-							
-							//Add focus class
-							$holder.addClass('focus');
-							
-							
-							THIS.radioEnable($item);
-
-							//Get group Name
-							var radio_name = $item.attr('name');
-
-							var $group = $('input[name="' + radio_name + '"]');
-
-							//Set checked/unchecked for each element in group
-							$group.each(function () {
-								
-								if ($(this).is(':checked')) {
-									
-									THIS.radioEnable($(this));
-									//Callback
-									settings.onChange(true, $(this).parent(), $(this));
-									
-								} else {
-									
-									THIS.radioDisable($(this));
-									//Callback
-									settings.onChange(false, $(this).parent(), $(this));
-									
-								}
-
-							});
-
-						},
-
-						focusout: function () {
-							
-							var $this = $(this);
-
-							setTimeout(function () {
-								
-								if (!$this.is(':focus')) {
-									
-									$holder.removeClass('focus');
-									
-								}
-								
-							}, 10);
-							
-						}
-					});
-
-					$holder.click(function () {
-						
-						//Add focus
-						$radio.focus();
-						
-					});
-
-					//Disable usual click functionality
-					$radio.click(function (e) {
-						
-						e.stopPropagation();
-						e.preventDefault();
-						
-					});
-
-				}
-			},
-
-			/*Private*/
-
-			checkboxEnable: function ($checkbox) {
-				
-				$checkbox.parent().removeClass(settings.checkbox.iconClass);
-				$checkbox.parent().removeClass('unchecked');
-
-				$checkbox.parent().addClass(settings.checkbox.iconClass);
-				$checkbox.parent().addClass('checked');
-				$checkbox.prop('checked', true).trigger('change');
-				
-					
-			},
-
-			checkboxDisable: function ($checkbox) {
-				
-				$checkbox.parent().removeClass(settings.checkbox.iconClass);
-				$checkbox.parent().addClass('unchecked');
-				$checkbox.prop('checked', false).trigger('change');
-				
-				
-			},
-
-			radioEnable: function ($radio) {
-				
-				$radio.parent().removeClass(settings.radio.iconClass);
-				$radio.parent().removeClass('unchecked');
-
-				$radio.parent().addClass(settings.radio.iconClass);
-				$radio.parent().addClass('checked');
-				$radio.prop('checked', true).trigger('change');
-				
-				
-					
-			},
-
-			radioDisable: function ($radio) {
-				
-				$radio.parent().removeClass('checked');
-				$radio.parent().removeClass(settings.radio.iconClass);
-				$radio.parent().addClass('unchecked');
-				$radio.prop('checked', false).trigger('change');
-				
-				
-			}
-		};
-
-		//Loop through elements
-		$elements.each(function (i, val) {
-
-			var $this = $(this);
-
-			//Check for checkbox
-			if ($this.is("input[type=checkbox]")) {
-				
-				//Setup checkboxes
-				form.checkbox($this);
-				
+    var defaults = {
+        checkbox: {
+            facadeClass: 'checkradios-checkbox',
+            iconClass: 'icon-checkradios-checkmark'
+        },
+        radio: {
+            facadeClass: 'checkradios-radio',
+            iconClass: 'icon-checkradios-circle'
+        }
+    };
+
+    $.fn.checkradios = function (options) {
+        var settings = $.extend(defaults, options);
+
+        this.each(function () {
+			var element = $(this);
+
+			if (element.is("input[type=checkbox]")) {
+				initCheckbox(element, settings);
 			}
 
-			//Check for radio
-			if ($this.is("input[type=radio]")) {
-				
-				//Setup checkboxes
-				form.radio($this);
-				
+			else if (element.is("input[type=radio]")) {
+				initRadio(element, settings);
 			}
+        });
 
-			return this;
-		});
+        return this;
+    }
 
-	};
+    function initCheckbox(checkbox, settings) {
+	    var facade = $('<div/>')
+            .addClass(settings.checkbox.facadeClass)
+            .addClass(checkbox.attr('class'));
 
-}(jQuery));
+        checkbox.replaceWith(facade).appendTo(facade);
+
+        facade.on('click mousedown mouseup', function(event) {
+            event.target = checkbox[0];
+            checkbox.trigger(event);
+        });
+
+        facade.on('click', function() {
+            checkbox.focus();
+        });
+
+        checkbox.on('focus', function() {
+            facade.addClass('focus');
+        });
+
+        checkbox.on('blur', function() {
+            facade.removeClass('focus');
+        });
+
+        checkbox.on('change', function() {
+			facade.toggleClass(settings.checkbox.iconClass, checkbox.prop('checked'));
+        });
+
+        checkbox.on('click mousedown mouseup', function(event) {
+			event.stopPropagation();
+        });
+    }
+
+    function initRadio(radio, settings) {
+	    var facade = $('<div/>')
+            .addClass(settings.radio.facadeClass)
+            .addClass(radio.attr('class'));
+
+        var group = $('input:radio[name=' + radio.attr('name') + ']');
+
+        radio.replaceWith(facade).appendTo(facade);
+
+        facade.on('click mousedown mouseup', function(event) {
+            event.target = radio[0];
+            radio.trigger(event);
+        });
+
+        facade.on('click', function() {
+            radio.focus();
+        });
+
+        radio.on('focus', function() {
+            facade.addClass('focus');
+        });
+
+        radio.on('blur', function() {
+            facade.removeClass('focus');
+        });
+
+        radio.on('change', function() {
+            group.each(function() {
+                $(this).parent().toggleClass(settings.radio.iconClass, this.checked)
+            });
+        });
+
+        radio.on('click mousedown mouseup', function(event) {
+			event.stopPropagation();
+        });
+    }
+
+})(jQuery);
+
+$(document).ready(function () {
+    $('input:checkbox').checkradios();
+    $('input:radio').checkradios();
+});
+

--- a/js/jquery.checkradios.js
+++ b/js/jquery.checkradios.js
@@ -70,6 +70,8 @@
 
         element.replaceWith(facade).appendTo(facade);
 
+        element.data('checkRadiosFacade', facade);
+
         var group = element.is(':radio')
             ? $('input:radio[name=' + element.attr('name') + ']')
             : element;

--- a/js/jquery.checkradios.js
+++ b/js/jquery.checkradios.js
@@ -95,7 +95,7 @@
 
         element.on('sync.checkRadios', function() {
 			facade.toggleClass(settings.iconClass, element.prop('checked'));
-        });
+        }).trigger('sync.checkRadios');
 
         element.on('change.checkRadios', function() {
             group.trigger('sync.checkRadios');

--- a/js/jquery.checkradios.js
+++ b/js/jquery.checkradios.js
@@ -34,19 +34,17 @@
 */
 
 (function ($) {
-    var defaults = {
-        checkbox: {
-            facadeClass: 'checkradios-checkbox',
-            iconClass: 'icon-checkradios-checkmark'
-        },
-        radio: {
-            facadeClass: 'checkradios-radio',
-            iconClass: 'icon-checkradios-circle'
-        }
-    };
-
     $.fn.checkradios = function (options) {
-        var settings = $.extend(defaults, options);
+        var settings = $.extend(true, {
+            checkbox: {
+                facadeClass: 'checkradios-checkbox',
+                iconClass: 'icon-checkradios-checkmark'
+            },
+            radio: {
+                facadeClass: 'checkradios-radio',
+                iconClass: 'icon-checkradios-circle'
+            }
+        }, options);
 
         this.each(function () {
 			var element = $(this);

--- a/js/jquery.checkradios.js
+++ b/js/jquery.checkradios.js
@@ -110,9 +110,3 @@
     }
 
 })(jQuery);
-
-$(document).ready(function () {
-    $('input:checkbox').checkradios();
-    $('input:radio').checkradios();
-});
-

--- a/js/jquery.checkradios.js
+++ b/js/jquery.checkradios.js
@@ -52,88 +52,18 @@
 			var element = $(this);
 
 			if (element.is("input[type=checkbox]")) {
-				initCheckbox(element, settings);
+                init(element, settings.checkbox)
 			}
 
 			else if (element.is("input[type=radio]")) {
-				initRadio(element, settings);
+                init(element, settings.radio)
 			}
         });
 
         return this;
     }
 
-    function initCheckbox(checkbox, settings) {
-	    var facade = $('<div/>')
-            .addClass(settings.checkbox.facadeClass)
-            .addClass(checkbox.attr('class'));
-
-        checkbox.replaceWith(facade).appendTo(facade);
-
-        facade.on('click mousedown mouseup', function(event) {
-            event.target = checkbox[0];
-            checkbox.trigger(event);
-        });
-
-        facade.on('click', function() {
-            checkbox.focus();
-        });
-
-        checkbox.on('focus', function() {
-            facade.addClass('focus');
-        });
-
-        checkbox.on('blur', function() {
-            facade.removeClass('focus');
-        });
-
-        checkbox.on('change', function() {
-			facade.toggleClass(settings.checkbox.iconClass, checkbox.prop('checked'));
-        });
-
-        checkbox.on('click mousedown mouseup', function(event) {
-			event.stopPropagation();
-        });
-    }
-
-    function initRadio(radio, settings) {
-	    var facade = $('<div/>')
-            .addClass(settings.radio.facadeClass)
-            .addClass(radio.attr('class'));
-
-        var group = $('input:radio[name=' + radio.attr('name') + ']');
-
-        radio.replaceWith(facade).appendTo(facade);
-
-        facade.on('click mousedown mouseup', function(event) {
-            event.target = radio[0];
-            radio.trigger(event);
-        });
-
-        facade.on('click', function() {
-            radio.focus();
-        });
-
-        radio.on('focus', function() {
-            facade.addClass('focus');
-        });
-
-        radio.on('blur', function() {
-            facade.removeClass('focus');
-        });
-
-        radio.on('change', function() {
-            group.each(function() {
-                $(this).parent().toggleClass(settings.radio.iconClass, this.checked)
-            });
-        });
-
-        radio.on('click mousedown mouseup', function(event) {
-			event.stopPropagation();
-        });
-    }
-
-    function initGeneric(element, settings) {
+    function init(element, settings) {
 	    var facade = $('<div/>')
             .addClass(settings.facadeClass)
             .addClass(element.attr('class'));

--- a/js/jquery.checkradios.js
+++ b/js/jquery.checkradios.js
@@ -74,20 +74,20 @@
             ? $('input:radio[name=' + element.attr('name') + ']')
             : element;
 
-        facade.on('click mousedown mouseup', function(event) {
+        facade.on('click.checkRadios mousedown.checkRadios mouseup.checkRadios', function(event) {
             event.target = element[0];
             element.trigger(event);
         });
 
-        facade.on('click', function() {
+        facade.on('click.checkRadios', function() {
             element.focus();
         });
 
-        element.on('focus', function() {
+        element.on('focus.checkRadios', function() {
             facade.addClass('focus');
         });
 
-        element.on('blur', function() {
+        element.on('blur.checkRadios', function() {
             facade.removeClass('focus');
         });
 
@@ -95,11 +95,11 @@
 			facade.toggleClass(settings.iconClass, element.prop('checked'));
         });
 
-        element.on('change', function() {
+        element.on('change.checkRadios', function() {
             group.trigger('checkradioSync');
         });
 
-        element.on('click mousedown mouseup', function(event) {
+        element.on('click.checkRadios mousedown.checkRadios mouseup.checkRadios', function(event) {
             // When the facade passes the event to the control, don't
             // allow it to propagate back up to the facade, infinitely
             // recursing. Propogation from the facade will still happen.

--- a/js/jquery.checkradios.js
+++ b/js/jquery.checkradios.js
@@ -51,13 +51,13 @@
         this.each(function () {
 			var element = $(this);
 
-			if (element.is("input[type=checkbox]")) {
-                init(element, settings.checkbox)
-			}
+            var elementSettings = settings[element.prop('type')];
+            if (!elementSettings) return;
 
-			else if (element.is("input[type=radio]")) {
-                init(element, settings.radio)
-			}
+            var priorFacade = element.data('checkRadiosFacade');
+            if (priorFacade) revert(element, priorFacade);
+
+            init(element, elementSettings);
         });
 
         return this;
@@ -93,12 +93,12 @@
             facade.removeClass('focus');
         });
 
-        element.on('checkradioSync', function() {
+        element.on('sync.checkRadios', function() {
 			facade.toggleClass(settings.iconClass, element.prop('checked'));
         });
 
         element.on('change.checkRadios', function() {
-            group.trigger('checkradioSync');
+            group.trigger('sync.checkRadios');
         });
 
         element.on('click.checkRadios mousedown.checkRadios mouseup.checkRadios', function(event) {
@@ -109,4 +109,8 @@
         });
     }
 
+    function revert(element, facade) {
+        facade.replaceWith(element).remove();
+        element.off('.checkRadios');
+    }
 })(jQuery);


### PR DESCRIPTION
At my job, we are using Checkradios, but we keep hitting problems with other pieces of functionality that are do not work with the plugin. I wound up making a lot of patches to our code to work around the plugin.

I did initially look for another option, but Checkradios is the only plugin I can find that allows for arbitrary colors, instead of using pre-rendered images. Your approach with the fonts is pretty great, and I think this is a unique and valuable part of the jQuery infrastructure.

I wound up re-writing the Javascript in my spare time, and this is the result, along with a few new things in the demo page to show what is working better here.

Main improvements:
- Generally simplified code
- Synchronizes consistently when other scripts change the status of controls
- Disabled checkboxes function as expected
- Labels function as expected
